### PR TITLE
Devp/v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.1.0] - 2021-04-15
+
 - Add: input release: Whether to push release versions
 - Add: input pre-release: Whether to push pre-release versions
 - Add: input tag-release: After pushing a new gem version, git tag with the version string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Add input release: Whether to push release versions
+- Add input pre-release: Whether to push pre-release versions
+- Add input tag-release: After pushing a new gem version, git tag with the version string
+
 ## [1.0.0] - 2021-04-15
 
 - Add basic action that pushes gems to the repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
-- Add input release: Whether to push release versions
-- Add input pre-release: Whether to push pre-release versions
-- Add input tag-release: After pushing a new gem version, git tag with the version string
+- Add: input release: Whether to push release versions
+- Add: input pre-release: Whether to push pre-release versions
+- Add: input tag-release: After pushing a new gem version, git tag with the version string
+- Add: output pushed-version: the version of the gem pushed to the repository
 
 ## [1.0.0] - 2021-04-15
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ If the gem version already exists in the repo the action will no-op and still se
 
 ## Usage
 
+The action expects that you have already checked out your gem and setup your ruby environment (bundle installed), such that gem and ruby commands are availiable. The easiest way to do this is using `actions/checkout` and `ruby/setup-ruby` actions with a `.ruby-version` file. See example below.
+
 ### Basic Setup
 
 Build and push all new version of the gem:
 
 ```yaml
     steps:
+    # Setup ruby environment
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1 # .ruby-version
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ If the gem version already exists in the repo the action will no-op and still se
 
 ## Usage
 
+### Basic Setup
+
+Build and push all new version of the gem:
+
 ```yaml
     steps:
     - uses: actions/checkout@v2
@@ -36,6 +40,62 @@ If you want to use a different gem host or key:
          gem_host_api_key: ${{ secrets.EXAMPLE_APYI_KEY }}
 ```
 
+### Separate release and pre-release workflow
+
+You probably don't want to push all versions from any branch. More likely you would want to push release versions from your default branch (e.g. main) and pre-release from PR builds. To help with this the release and pre-release inputs can be used:
+
+```yaml
+name: Gem Build and Release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Gem / Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+    - name: Test
+      run: bundle exec rake
+
+  release:
+    name: Gem / Release
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+
+    - name: Build Gem
+      run: bundle exec rake build
+
+    - name: Setup GPR
+      uses: fac/rubygems-setup-gpr-action@v1
+      with:
+        token: ${{ secrets.github_token }}
+
+    # Release production gem version from default branch
+    - name: Push Release Gem
+      if:   github.ref == 'refs/heads/main'
+      uses: fac/rubygems-push-action@devp/v1.1.0
+
+    # PR branch builds will release pre-release gems
+    - name: Push Pre-Release Gem
+      if:   github.ref != 'refs/heads/main'
+      uses: fac/rubygems-push-action@devp/v1.1.0
+      with:
+        release: false
+        pre-release: true
+```
+
+Here we run the test on its own job, so that it gets it's own status on the PR, that you can require separately from the release job in your branch protection.
+The release job runs if the tests pass, we always package the gem to test that works. For release we use a conditional along with the actions inputs to push release versions for the main branch only and push pre-releases for PR.
+
 ## Inputs
 
 ### package-glob
@@ -49,9 +109,28 @@ File glob to match the gem file to push. The default `pkg/*.gem` picks up gems b
         package-glob: build/special.gem
 ```
 
+### release
+
+Whether to push new release versions of the gem. Defaults to true.
+
+### pre-release
+
+Whether to push new pre-release versions of the gem. Defaults to true.
+
+### tag-release
+
+When true (the default), after pushing a new gem version tag the repo with
+the version number prefixed with `v`. e.g. after pushing version `0.1.0`, the
+tag will be `v0.1.0`. This is the same behavior as `gem tag`, but internally
+implemented to work with older gem versions.
+
+The tag commit and push will be made as the author of the commit being tagged.
+
 ## Outputs
 
-None.
+### pushed-version
+
+If we pushed a gem to the repository, this will be set to the version pushed.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ jobs:
     # Release production gem version from default branch
     - name: Push Release Gem
       if:   github.ref == 'refs/heads/main'
-      uses: fac/rubygems-push-action@devp/v1.1.0
+      uses: fac/rubygems-push-action@v1
 
     # PR branch builds will release pre-release gems
     - name: Push Pre-Release Gem
       if:   github.ref != 'refs/heads/main'
-      uses: fac/rubygems-push-action@devp/v1.1.0
+      uses: fac/rubygems-push-action@v1
       with:
         release: false
         pre-release: true

--- a/action.yml
+++ b/action.yml
@@ -23,39 +23,10 @@ runs:
       shell: bash
       env:
         # Expects GEM_HOST and GEM_HOST_API_KEY to be set
-        GEM_GLOB: ${{ inputs.package-glob }}
-        ACTION_PATH: ${{ github.action_path }}
+        INPUT_PACKAGE_GLOB: ${{ inputs.package-glob }}
         INPUT_RELEASE: ${{ inputs.release }}
         INPUT_PRE_RELEASE: ${{ inputs.pre-release }}
         INPUT_TAG_RELEASE: ${{ inputs.tag-release }}
       run: |
-        PATH="$ACTION_PATH:$PATH"
-
-        if parse-gemspec --is-pre-release; then
-          if [[ $INPUT_PRE_RELEASE != true ]]; then
-            echo Ignoring pre-release. Set input pre-release: true, to release
-            exit 0
-          fi
-        elif [[ $INPUT_RELEASE != true ]]; then
-          echo Ignoring release. Set input release: true, to release
-          exit 0
-        fi
-
-        if ! gem push --host "$GEM_HOST" $GEM_GLOB | tee push.out; then
-          gemerr=$?
-          if grep -q "has already been pushed" push.out; then
-            echo Gem Already Pushed
-            exit 0
-          fi
-          echo ::error::Gem Push Failed
-          cat push.out | sed 's/^/::error::/'
-          exit $gemerr
-        fi
-
-        if [[ $INPUT_TAG_RELEASE == true ]]; then
-          tagname="v$( parse-gemspec --version )"
-          git tag -a -m "Gem release $tagname" $tagname
-          git push origin $tagname
-        fi
-
-        exit 0
+        PATH="${{ github.action_path }}:$PATH"
+        gem-push-action

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,20 @@
 # See: https://docs.github.com/en/actions/creating-actions
 name: Gem Push
 author: FreeAgent
-description: Push gem packages to a rubygems compatible repo
+description: Push gem packages to a rubygems compatible repository
 inputs:
   package-glob:
-    description: "File glob to match the .gem files to push"
+    description: File glob to match the .gem files to push
     default: "pkg/*.gem"
+  release:
+    description: Whether to push release versions
+    default: true
+  pre-release:
+    description: Whether to push pre-release versions
+    default: true
+  tag-release:
+    description: After pushing a new gem version, git tag with the version string
+    default: true
 
 runs:
   using: "composite"
@@ -15,10 +24,26 @@ runs:
       env:
         # Expects GEM_HOST and GEM_HOST_API_KEY to be set
         GEM_GLOB: ${{ inputs.package-glob }}
+        ACTION_PATH: ${{ github.action_path }}
+        INPUT_RELEASE: ${{ inputs.release }}
+        INPUT_PRE_RELEASE: ${{ inputs.pre-release }}
+        INPUT_TAG_RELEASE: ${{ inputs.tag-release }}
       run: |
+        PATH="$ACTION_PATH:$PATH"
+
+        if parse-gemspec --is-pre-release; then
+          if [[ $INPUT_PRE_RELEASE != true ]]; then
+            echo Ignoring pre-release. Set input pre-release: true, to release
+            exit 0
+          fi
+        elif [[ $INPUT_RELEASE != true ]]; then
+          echo Ignoring release. Set input release: true, to release
+          exit 0
+        fi
+
         if ! gem push --host "$GEM_HOST" $GEM_GLOB | tee push.out; then
           gemerr=$?
-          if grep "has already been pushed" push.out; then
+          if grep -q "has already been pushed" push.out; then
             echo Gem Already Pushed
             exit 0
           fi
@@ -26,4 +51,11 @@ runs:
           cat push.out | sed 's/^/::error::/'
           exit $gemerr
         fi
+
+        if [[ $INPUT_TAG_RELEASE == true ]]; then
+          tagname="v$( parse-gemspec --version )"
+          git tag -a -m "Gem release $tagname" $tagname
+          git push origin $tagname
+        fi
+
         exit 0

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,16 @@ inputs:
   tag-release:
     description: After pushing a new gem version, git tag with the version string
     default: true
+outputs:
+  pushed-version:
+    description: "The version of the gem pushed to the repository"
+    value: ${{ steps.push-gem.outputs.pushed-version }}
 
 runs:
   using: "composite"
   steps:
     - name: Push Gem
+      id: push-gem
       shell: bash
       env:
         # Expects GEM_HOST and GEM_HOST_API_KEY to be set

--- a/gem-push-action
+++ b/gem-push-action
@@ -1,0 +1,38 @@
+#!/usr/bin/bash 
+set -e -o pipefail
+
+if parse-gemspec --is-pre-release; then
+    if [[ $INPUT_PRE_RELEASE != true ]]; then
+    echo Ignoring pre-release. Set input pre-release: true, to release
+    exit 0
+    fi
+elif [[ $INPUT_RELEASE != true ]]; then
+    echo Ignoring release. Set input release: true, to release
+    exit 0
+fi
+
+# tee the output to get it in the logs but capture as we can't tell why gem
+# push failed from the exit code, so need to grep the output. Gem existing is
+# ok, other errors not. Avoids playing games setting up auth up differently for
+# gem query.
+# Note: the glob is intentially unquoted, we want a glob!
+if ! gem push --host "$GEM_HOST" $INPUT_PACKAGE_GLOB | tee push.out; then
+    gemerr=$?
+    if grep -q "has already been pushed" push.out; then
+    echo Gem Already Pushed
+    exit 0
+    fi
+    echo ::error::Gem Push Failed
+    sed 's/^/::error::/' push.out
+    exit $gemerr
+fi
+
+if [[ $INPUT_TAG_RELEASE == true ]]; then
+    tagname="v$( parse-gemspec --version )"
+    git config user.name "$(git log -1 --pretty=format:%an)"
+    git config user.email "$(git log -1 --pretty=format:%ae)"
+    git tag -a -m "Gem release $tagname" "$tagname"
+    git push origin "$tagname"
+fi
+
+exit 0

--- a/gem-push-action
+++ b/gem-push-action
@@ -27,6 +27,8 @@ if ! gem push --host "$GEM_HOST" $INPUT_PACKAGE_GLOB | tee push.out; then
     exit $gemerr
 fi
 
+echo "::set-output name=pushed-version::$( parse-gemspec --version )"
+
 if [[ $INPUT_TAG_RELEASE == true ]]; then
     tagname="v$( parse-gemspec --version )"
     git config user.name "$(git log -1 --pretty=format:%an)"

--- a/gem-push-action
+++ b/gem-push-action
@@ -3,11 +3,11 @@ set -e -o pipefail
 
 if parse-gemspec --is-pre-release; then
     if [[ $INPUT_PRE_RELEASE != true ]]; then
-    echo Ignoring pre-release. Set input pre-release: true, to release
+    echo "Ignoring pre-release. To release, pass pre-release: true as an input"
     exit 0
     fi
 elif [[ $INPUT_RELEASE != true ]]; then
-    echo Ignoring release. Set input release: true, to release
+    echo "Ignoring release. To release, pass release: true as an input"
     exit 0
 fi
 

--- a/gem-push-action
+++ b/gem-push-action
@@ -13,7 +13,7 @@ fi
 
 # tee the output to get it in the logs but capture as we can't tell why gem
 # push failed from the exit code, so need to grep the output. Gem existing is
-# ok, other errors not. Avoids playing games setting up auth up differently for
+# ok, other errors not. Avoids playing games setting up auth differently for
 # gem query.
 # Note: the glob is intentially unquoted, we want a glob!
 if ! gem push --host "$GEM_HOST" $INPUT_PACKAGE_GLOB | tee push.out; then

--- a/parse-gemspec
+++ b/parse-gemspec
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "json"
 require 'optparse'
 
 gemspecs = Dir["*.gemspec"]
@@ -18,26 +17,21 @@ end
 spec = Gem::Specification.load(gemspecs.first)
 exit 10 unless spec
 
-# json_hash = {
-#     name: spec.name,
-#     version: spec.version,
-#     isPreRelease: spec.version.prerelease?
-# }
-# puts json_hash.to_json
-
-
+def puts!(msg)
+  puts msg
+  exit
+end
 
 OptionParser.new do |opts|
   opts.banner = "Usage: #{File.basename($0)} [options]"
   opts.on("-h", "--help", "Prints this help") do
-    puts opts
-    exit
+    puts! opts
   end
   opts.on("--name", "Output gemspec name") do |v|
-    puts spec.name
+    puts! spec.name
   end
   opts.on("--version", "Output gemspec gem version") do |v|
-    puts spec.version
+    puts! spec.version
   end
   opts.on("--is-pre-release", "Exit 0 if pre-release, 1 otherwise") do |v|
     exit 0 if spec.version.prerelease?

--- a/parse-gemspec
+++ b/parse-gemspec
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+require "json"
+require 'optparse'
+
+gemspecs = Dir["*.gemspec"]
+
+if gemspecs.empty?
+    warn "No gemspec found"
+    exit 10
+end
+
+if gemspecs.count > 1
+    warn "More than one gemspec found"
+    exit 10
+end
+
+spec = Gem::Specification.load(gemspecs.first)
+exit 10 unless spec
+
+# json_hash = {
+#     name: spec.name,
+#     version: spec.version,
+#     isPreRelease: spec.version.prerelease?
+# }
+# puts json_hash.to_json
+
+
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename($0)} [options]"
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+  opts.on("--name", "Output gemspec name") do |v|
+    puts spec.name
+  end
+  opts.on("--version", "Output gemspec gem version") do |v|
+    puts spec.version
+  end
+  opts.on("--is-pre-release", "Exit 0 if pre-release, 1 otherwise") do |v|
+    exit 0 if spec.version.prerelease?
+    exit 1
+  end
+end.parse!


### PR DESCRIPTION
This adds handling for pre-releases, with a setup that still allows the workflow to direct the flow with the action not needing to know those details. [Here you can see it in action](https://github.com/fac/github-scanner/blob/devp/seperate-gem-actions/.github/workflows/gem-build-release.yml), with [much testing](https://github.com/fac/github-scanner/actions), all explained in the docs (I hope).

It also adds tagging after release. This is a little cheeky here, but it gets us to feature complete on moving the current gem builds over. A bit of lift and shift to keep us moving.

Some internal work here as well. Pulls out the bash script to its own exe, easier to edit, test and run local linting on. Pulls out the gemspec stuff to a ruby command (ported from the jenkinslib).

Note: Action naming is not addressed in this PR. Once this is merged, will follow up with name change PR.

See: fac/dev-platform#62