### PR TITLE
Devp/v2

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,26 @@
+name: Lint Code Base
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0 # Full history to get a proper list of changed files within `super-linter`
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH:  true
+          VALIDATE_YAML:  true
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN:   ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+TODO: v2 changes
+
 ## [Unreleased]
 ## [1.3.0] - 2021-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 TODO: v2 changes
 
 ## [Unreleased]
+
+## [2.0.0] - 2021-04-26
+
+- Change: Don't pass the gem host around as an environment variable, extract from the gemspec.
+- Change: Don't pass gem keys around in environment variables anymore. Use the installed creds by key name.
+- Add: input `key` to set the key name in gem credentials to use.
+- Change: Release/pre-release inputs collapsed into single pre-release input. Push is either release or pre-release version, can't do both (or none!) in the same call anymore.
+- Add: Add linter for action code.
+- Change: `tag-release` input renamed to just `tag`.
+- Change: Use command line args instead of env variables for the internal command.
+
 ## [1.3.0] - 2021-04-16
 
 - Fix: clean shell log handling for `gem push` call

--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ Build and push all new version of the gem:
         key: github
 ```
 
-Note, that the ruby-gem-push-action, will push to the host given in the gemspec. The token needs to match. Trying to push to a different host will fail.
+Note that the ruby-gem-push-action will push to the host given in the gemspec. The token needs to match. Trying to push to a different host will fail.
 
 ### Separate release and pre-release workflow
 
-
-By the default, the action releases, (er!) release versions, that is, non pre-release versions, those are skipped over with a message. Setting the input `pre-release: true`, reverses that, releasing new pre-release versions and skipping over live releases. That way, you can have 2 calls to the action, using the workflow to decide the logic.
+By default, the action only acts on non-pre-release versions, and prints a message if it thinks the gem has a pre-release version number. If you set the input option `pre-release: true`, then it will only act on pre-release versions, and will skip over regular versions. That way, you can have 2 calls to the action, using the workflow to decide the logic.
 
 Say you want to push release versions from your default branch (main) and pre-release versions from PR builds:
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: FreeAgent
 description: Push gem packages to a rubygems compatible repository
 inputs:
   key:
-    description: "Name of credentials key to use from ~/.gem/credentials. Use github for gh packages."
+    description: "Name of credentials key to use from ~/.gem/credentials."
     default: ""
   gem-glob:
     description: File glob to match the .gem files to push
@@ -29,5 +29,5 @@ runs:
       run: |
         PATH="${{ github.action_path }}:$PATH"
         args=""
-        '${{ inputs.tag }}' && args="$args -t"
+        [ '${{ inputs.tag }}' == true ] && args="$args -t"
         gem-push-action -k "${{inputs.key}}" $args ${{inputs.gem-glob}}

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ name: Gem Push
 author: FreeAgent
 description: Push gem packages to a rubygems compatible repository
 inputs:
+  key:
+    description: "Name of credentials key to use from ~/.gem/credentials. Use github for gh packages."
+    default: ""
   package-glob:
     description: File glob to match the .gem files to push
     default: "pkg/*.gem"
@@ -15,9 +18,6 @@ inputs:
   tag-release:
     description: After pushing a new gem version, git tag with the version string
     default: true
-  key-name:
-    description: "Name of credentials key to use from ~/.gem/credentials. Use github for gh packages."
-    default: ""
 outputs:
   pushed-version:
     description: "The version of the gem pushed to the repository"
@@ -35,7 +35,7 @@ runs:
         INPUT_RELEASE:      ${{ inputs.release }}
         INPUT_PRE_RELEASE:  ${{ inputs.pre-release }}
         INPUT_TAG_RELEASE:  ${{ inputs.tag-release }}
-        INPUT_KEY_NAME:     ${{ inputs.key-name }}
+        INPUT_KEY:          ${{ inputs.key }}
       run: |
         PATH="${{ github.action_path }}:$PATH"
         gem-push-action

--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,8 @@ runs:
     - name: Push Gem
       id: push-gem
       shell: bash
-      env:
-        # Expects GEM_HOST and GEM_HOST_API_KEY to be set
-        INPUT_PRE_RELEASE:  ${{ inputs.pre-release }}
-        INPUT_TAG_RELEASE:  ${{ inputs.tag-release }}
-        INPUT_KEY:          ${{ inputs.key }}
       run: |
-        PATH="${{ github.action_path }}:$PATH"
-        gem-push-action ${{ inputs.package-glob }}
+        #PATH="${{ github.action_path }}:$PATH"
+        args=""
+        '${{ inputs.tag-release }}' && args="$args -t" 
+        gem-push-action -k "${{inputs.key}}" $args ${{ inputs.package-glob }}

--- a/action.yml
+++ b/action.yml
@@ -9,12 +9,9 @@ inputs:
   package-glob:
     description: File glob to match the .gem files to push
     default: "pkg/*.gem"
-  release:
-    description: Whether to push release versions
-    default: true
   pre-release:
-    description: Whether to push pre-release versions
-    default: true
+    description: Whether to push pre-release versions, instead of release versions (the default).
+    default: false
   tag-release:
     description: After pushing a new gem version, git tag with the version string
     default: true
@@ -31,11 +28,9 @@ runs:
       shell: bash
       env:
         # Expects GEM_HOST and GEM_HOST_API_KEY to be set
-        INPUT_PACKAGE_GLOB: ${{ inputs.package-glob }}
-        INPUT_RELEASE:      ${{ inputs.release }}
         INPUT_PRE_RELEASE:  ${{ inputs.pre-release }}
         INPUT_TAG_RELEASE:  ${{ inputs.tag-release }}
         INPUT_KEY:          ${{ inputs.key }}
       run: |
         PATH="${{ github.action_path }}:$PATH"
-        gem-push-action
+        gem-push-action ${{ inputs.package-glob }}

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   tag-release:
     description: After pushing a new gem version, git tag with the version string
     default: true
+  key-name:
+    description: "Name of credentials key to use from ~/.gem/credentials. Use github for gh packages."
+    default: ""
 outputs:
   pushed-version:
     description: "The version of the gem pushed to the repository"
@@ -29,9 +32,10 @@ runs:
       env:
         # Expects GEM_HOST and GEM_HOST_API_KEY to be set
         INPUT_PACKAGE_GLOB: ${{ inputs.package-glob }}
-        INPUT_RELEASE: ${{ inputs.release }}
-        INPUT_PRE_RELEASE: ${{ inputs.pre-release }}
-        INPUT_TAG_RELEASE: ${{ inputs.tag-release }}
+        INPUT_RELEASE:      ${{ inputs.release }}
+        INPUT_PRE_RELEASE:  ${{ inputs.pre-release }}
+        INPUT_TAG_RELEASE:  ${{ inputs.tag-release }}
+        INPUT_KEY_NAME:     ${{ inputs.key-name }}
       run: |
         PATH="${{ github.action_path }}:$PATH"
         gem-push-action

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,13 @@ inputs:
   key:
     description: "Name of credentials key to use from ~/.gem/credentials. Use github for gh packages."
     default: ""
-  package-glob:
+  gem-glob:
     description: File glob to match the .gem files to push
     default: "pkg/*.gem"
   pre-release:
     description: Whether to push pre-release versions, instead of release versions (the default).
     default: false
-  tag-release:
+  tag:
     description: After pushing a new gem version, git tag with the version string
     default: true
 outputs:
@@ -27,7 +27,7 @@ runs:
       id: push-gem
       shell: bash
       run: |
-        #PATH="${{ github.action_path }}:$PATH"
+        PATH="${{ github.action_path }}:$PATH"
         args=""
-        '${{ inputs.tag-release }}' && args="$args -t" 
-        gem-push-action -k "${{inputs.key}}" $args ${{ inputs.package-glob }}
+        '${{ inputs.tag }}' && args="$args -t"
+        gem-push-action -k "${{inputs.key}}" $args ${{inputs.gem-glob}}

--- a/gem-push-action
+++ b/gem-push-action
@@ -1,5 +1,41 @@
-#!/usr/bin/bash 
+#!/usr/bin/env bash
 set -e -o pipefail
+
+# Get access to ./parse-gemspec and be callable from anywhere
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
+PATH="$SRCDIR:$PATH"
+
+KEY=""
+PRE_RELEASE=false
+TAG_RELEASE=false
+
+usage() {
+  echo "Usage: $0 [-k KEY] [-p] GEMFILE"
+  echo
+  echo Options:
+  echo "  GEMFILE  The pre-built .gem pkg you want to push"
+  echo "  -k KEY   Set the gem host credentials key name. Default: '$KEY'"
+  echo "  -p       Do a pre-release, ignore otherwise. Default: $PRE_RELEASE"
+  echo "  -t       After pushing a new version, git tag the current ref. Default: $TAG_RELEASE"
+  echo "  -h       Show this help"
+  exit 0
+}
+
+while getopts ":hk:pt" opt; do
+  case ${opt} in
+    h ) usage
+      ;;
+    k ) KEY=$OPTARG
+      ;;
+    p ) PRE_RELEASE=true
+      ;;
+    t ) TAG_RELEASE=true
+      ;;
+    \? ) usage
+      ;;
+  esac
+done
+shift $((OPTIND -1))
 
 GEM_FILE="$1"
 
@@ -8,7 +44,7 @@ GEM_FILE="$1"
 push_host="$(parse-gemspec --push-host)"
 GEM_HOST="${GEM_HOST:-$push_host}"
 
-if parse-gemspec --is-pre-release && [[ $INPUT_PRE_RELEASE != true ]];
+if parse-gemspec --is-pre-release && [[ $PRE_RELEASE != true ]];
 then
     echo "Ignoring pre-release. To release, pass pre-release: true as an input"
     exit 0
@@ -17,7 +53,7 @@ fi
 # Capture as we can't tell why gem push failed from the exit code and it logs
 # everything to stdout, so need to grep the output. Gem existing is ok, other
 # errors not. Avoids playing games setting up auth differently for gem query.
-if ! gem push --key="$INPUT_KEY" --host "$GEM_HOST" "$GEM_FILE" >push.out; then
+if ! gem push --key="$KEY" --host "$GEM_HOST" "$GEM_FILE" >push.out; then
     gemerr=$?
     sed 's/^Error:/::error::/' push.out
     if grep -q "has already been pushed" push.out; then
@@ -28,7 +64,7 @@ fi
 
 echo "::set-output name=pushed-version::$( parse-gemspec --version )"
 
-if [[ $INPUT_TAG_RELEASE == true ]]; then
+if [[ $TAG_RELEASE == true ]]; then
     tagname="v$( parse-gemspec --version )"
     git config user.name "$(git log -1 --pretty=format:%an)"
     git config user.email "$(git log -1 --pretty=format:%ae)"

--- a/gem-push-action
+++ b/gem-push-action
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-# Get access to ./parse-gemspec and be callable from anywhere
-SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
-PATH="$SRCDIR:$PATH"
-
 KEY=""
 PRE_RELEASE=false
 TAG_RELEASE=false

--- a/gem-push-action
+++ b/gem-push-action
@@ -20,7 +20,7 @@ fi
 # everything to stdout, so need to grep the output. Gem existing is ok, other
 # errors not. Avoids playing games setting up auth differently for gem query.
 # Note: the glob is intentially unquoted, we want a glob!
-if ! gem push --key="$INPUT_KEY_NAME" --host "$GEM_HOST" $INPUT_PACKAGE_GLOB >push.out; then
+if ! gem push --key="$INPUT_KEY" --host "$GEM_HOST" $INPUT_PACKAGE_GLOB >push.out; then
     gemerr=$?
     sed 's/^Error:/::error::/' push.out
     if grep -q "has already been pushed" push.out; then

--- a/gem-push-action
+++ b/gem-push-action
@@ -1,6 +1,11 @@
 #!/usr/bin/bash 
 set -e -o pipefail
 
+# By default read the gem host from the gemspec, if they dont match the push
+# will fail! Allow override if GEM_HOST is already exported.
+push_host="$(parse-gemspec --push-host)"
+export GEM_HOST="${GEM_HOST:-$push_host}"
+
 if parse-gemspec --is-pre-release; then
     if [[ $INPUT_PRE_RELEASE != true ]]; then
     echo "Ignoring pre-release. To release, pass pre-release: true as an input"

--- a/gem-push-action
+++ b/gem-push-action
@@ -1,26 +1,23 @@
 #!/usr/bin/bash 
 set -e -o pipefail
 
+GEM_FILE="$1"
+
 # By default read the gem host from the gemspec, if they dont match the push
 # will fail! Allow override if GEM_HOST is already exported.
 push_host="$(parse-gemspec --push-host)"
-export GEM_HOST="${GEM_HOST:-$push_host}"
+GEM_HOST="${GEM_HOST:-$push_host}"
 
-if parse-gemspec --is-pre-release; then
-    if [[ $INPUT_PRE_RELEASE != true ]]; then
+if parse-gemspec --is-pre-release && [[ $INPUT_PRE_RELEASE != true ]];
+then
     echo "Ignoring pre-release. To release, pass pre-release: true as an input"
-    exit 0
-    fi
-elif [[ $INPUT_RELEASE != true ]]; then
-    echo "Ignoring release. To release, pass release: true as an input"
     exit 0
 fi
 
 # Capture as we can't tell why gem push failed from the exit code and it logs
 # everything to stdout, so need to grep the output. Gem existing is ok, other
 # errors not. Avoids playing games setting up auth differently for gem query.
-# Note: the glob is intentially unquoted, we want a glob!
-if ! gem push --key="$INPUT_KEY" --host "$GEM_HOST" $INPUT_PACKAGE_GLOB >push.out; then
+if ! gem push --key="$INPUT_KEY" --host "$GEM_HOST" "$GEM_FILE" >push.out; then
     gemerr=$?
     sed 's/^Error:/::error::/' push.out
     if grep -q "has already been pushed" push.out; then

--- a/gem-push-action
+++ b/gem-push-action
@@ -20,7 +20,7 @@ fi
 # everything to stdout, so need to grep the output. Gem existing is ok, other
 # errors not. Avoids playing games setting up auth differently for gem query.
 # Note: the glob is intentially unquoted, we want a glob!
-if ! gem push --host "$GEM_HOST" $INPUT_PACKAGE_GLOB >push.out; then
+if ! gem push --key="$INPUT_KEY_NAME" --host "$GEM_HOST" $INPUT_PACKAGE_GLOB >push.out; then
     gemerr=$?
     sed 's/^Error:/::error::/' push.out
     if grep -q "has already been pushed" push.out; then

--- a/parse-gemspec
+++ b/parse-gemspec
@@ -24,15 +24,15 @@ end
 
 OptionParser.new do |opts|
   opts.banner = "Usage: #{File.basename($0)} [options]"
-  opts.on("-h", "--help", "Prints this help") do
-    puts! opts
+  opts.on("-h", "--help", "Prints this help") do puts! opts end
+
+  opts.on("--name",      "Output name")        do |v| puts! spec.name end
+  opts.on("--version",   "Output gem version") do |v| puts! spec.version end
+  opts.on("--metadata",  "Output metadata")    do |v| puts! spec.metadata end
+  opts.on("--push-host", "Output metadata.allowed_push_host") do |v|
+    puts! spec.metadata.dig "allowed_push_host"
   end
-  opts.on("--name", "Output gemspec name") do |v|
-    puts! spec.name
-  end
-  opts.on("--version", "Output gemspec gem version") do |v|
-    puts! spec.version
-  end
+
   opts.on("--is-pre-release", "Exit 0 if pre-release, 1 otherwise") do |v|
     exit 0 if spec.version.prerelease?
     exit 1


### PR DESCRIPTION
Update the push action based on feedback from last reviews around passing the auth info around. Main change is realising we already have the push host in the gemspec!

- Change: Don't pass the gem host around as an environment variable, extract from the gemspec.
- Change: Don't pass gem keys around in environment variables anymore. Use the installed creds by key name.
- Add: input `key` to set the key name in gem credentials to use.
- Change: Release/pre-release inputs collapsed into single pre-release input. Push is either release or pre-release version, can't do both (or none!) in the same call anymore.
- Add: Add linter for action code.
- Change: `tag-release` input renamed to just `tag`.
- Change: Use command line args instead of env variables for the internal command.

This maybe a review that is easier on the whole file rather than the diff. Especially reading the README.

Tested: https://github.com/fac/github-scanner/pull/7

For: fac/dev-platform#35