### PR TITLE
Explicitly check the push host URL before attempting to push a gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 TODO: v2 changes
 
 ## [Unreleased]
+
+## [2.3.0] - 2021-05-19
+
+- Add: explicit preflight check on the push host, to work around gem failing successfully on malformed push hosts
+
 ## [2.2.0] - 2021-04-30
 
 - Fix: Bug with pre-release:false input getting ignored

--- a/gem-push-action
+++ b/gem-push-action
@@ -43,7 +43,7 @@ GEM_HOST="${GEM_HOST:-$push_host}"
 # test GEM_HOST, gem silently fails with no error if the GEM_HOST redirects
 # see https://github.com/rubygems/rubygems/issues/4458
 test_response_code=$(curl --silent --output /dev/null --write-out "%{http_code}" --request POST "$GEM_HOST/api/v1/gems")
-if [ $test_response_code != 401 ] # expecting an 'authentication required' response
+if [[ $test_response_code != 401 ]] # expecting an 'authentication required' response
 then
   echo "::error::Push host looks malformed! Got response of $test_response_code when requesting $GEM_HOST/api/vi/gems" >&2
   echo "::error::Check for HTTPS scheme & no trailing slashes on your allowed push host ($push_host)" >&2

--- a/gem-push-action
+++ b/gem-push-action
@@ -40,6 +40,16 @@ GEM_FILE="$1"
 push_host="$(parse-gemspec --push-host)"
 GEM_HOST="${GEM_HOST:-$push_host}"
 
+# test GEM_HOST, gem silently fails with no error if the GEM_HOST redirects
+# see https://github.com/rubygems/rubygems/issues/4458
+test_response_code=$(curl --silent --output /dev/null --write-out "%{http_code}" --request POST "$GEM_HOST/api/v1/gems")
+if [ $test_response_code != 401 ] # expecting an 'authentication required' response
+then
+  echo "::error::Push host looks malformed! Got response of $test_response_code when requesting $GEM_HOST/api/vi/gems" >&2
+  echo "::error::Check for HTTPS scheme & no trailing slashes on your allowed push host ($push_host)" >&2
+  exit 1
+fi
+
 if parse-gemspec --is-pre-release; then
   if [[ $PRE_RELEASE != true ]]; then
     echo "Ignoring pre-release. To release, pass pre-release: true as an input"


### PR DESCRIPTION
`gem` will immediately stop with no error if it encounters an unexpected
response when pushing a gem. To avoid this, I'm adding an explicit pre-flight
check that replicates the request `gem` will make, but wuth no authentication,
and testing for an 'Authentication required' response.

If the gem host URL has the wrong scheme or excess slashes, the gem host
usually responds with a redirect.
rubygems/rubygems#4458

fixes fac/dev-platform#202