### PR TITLE
Adding working-directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,20 @@ This action supports [debug logging](https://docs.github.com/en/actions/managing
 
 ## Inputs
 
+### working-directory
+Sets the working directory before all other steps occur. This is useful for cases where files like `.ruby-version` and `Gemfile` aren't located in the root directory. For example in a monorepo where the Ruby project is located in its own subfolder.
+
+```yaml
+    name: Push Gem
+      uses: fac/ruby-gem-push-action@v1
+      with:
+        working-directory: './ruby_project/'
+```
+
 ### gem-glob
 
 File glob to match the gem file to push. The default `pkg/*.gem` picks up gems built using `bundle exec rake build`. You may need to set this if your your gem builds another way.
+_Note_: `working-directory` is set before this step, therefore if both inputs are provided, this path will be relative to the `working-directory`.
 
 ```yaml
     - name: Push Gem

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   tag:
     description: After pushing a new gem version, git tag with the version string
     default: true
+  working-directory:
+    description: "The working directory of the ruby project. Useful for cases where files like .ruby-version and Gemfile aren't located in the root directory."
+    required: false
+    default: "."
 outputs:
   pushed-version:
     description: "The version of the gem pushed to the repository"
@@ -34,4 +38,5 @@ runs:
         args=""
         [ '${{ inputs.pre-release }}' == true ] && args="$args -p"
         [ '${{ inputs.tag }}' == true ] && args="$args -t"
+        [ ! -z ${{ inputs.working-directory }} ] && cd ${{ inputs.working-directory }}
         gem-push-action.sh -k "${{inputs.key}}" $args ${{inputs.gem-glob}}

--- a/parse-gemspec
+++ b/parse-gemspec
@@ -5,12 +5,12 @@ require 'optparse'
 gemspecs = Dir["*.gemspec"]
 
 if gemspecs.empty?
-    warn "No gemspec found"
+    warn "No gemspec found in #{Dir.pwd}"
     exit 10
 end
 
 if gemspecs.count > 1
-    warn "More than one gemspec found"
+    warn "More than one gemspec found in #{Dir.pwd}"
     exit 10
 end
 


### PR DESCRIPTION
Adding `working-directory` support, for the use case where the ruby project is not within the root directory (i.e. a monorepo with multiple subdirectories for separate projects).

Initially I'd looked at setting this within `gem-push-action.sh`, but the file globbing (`gem push --key="$KEY" --host "$GEM_HOST" "$GEM_FILE"`) failed to resolve after changing directory.
It's simpler just to change directory before running the script.