### PR TITLE
Switch to the new method of setting outputs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,13 +11,13 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0 # Full history to get a proper list of changed files within `super-linter`
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH:  true

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,9 +5,11 @@ jobs:
     name: runner / actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: actionlint
-        uses: reviewdog/action-actionlint@v1.2.0
+        uses: reviewdog/action-actionlint@v1.33.0
         with:
           fail_on_error: true
           reporter: github-pr-review
@@ -15,7 +17,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/gem-push-action.sh
+++ b/gem-push-action.sh
@@ -84,7 +84,7 @@ if ! gem push --key="$KEY" --host "$GEM_HOST" "$GEM_FILE" >push.out; then
     exit $gemerr
 fi
 
-echo "::set-output name=pushed-version::$( parse-gemspec --version )"
+echo "pushed-version=$(parse-gemspec --version)" >> "$GITHUB_OUTPUT"
 
 if [[ $TAG_RELEASE == true ]]; then
     tagname="v$( parse-gemspec --version )"


### PR DESCRIPTION
Part of fac/dev-platform#1271

Before:
```
echo "::set-output name=output_var::${output_string}"
```

After:
```
echo "output_var=${output_string}" >> "$GITHUB_OUTPUT"
```

Also now supports multiple outputs at once:
```
{
  echo "output_var_1=${output_string_2}"
  echo "output_var_2=${output_string_2}"
  echo "output_var_3=${output_string_3}"
} >> "$GITHUB_OUTPUT"
```
